### PR TITLE
Rendering boards for game history

### DIFF
--- a/grid.py
+++ b/grid.py
@@ -83,6 +83,10 @@ class Grid():
         self.castle_queenside = input
     def set_queening(self, input):
         self.queening = input
+    def set_white_coords(self, new_coords):
+        self.w_coords = np.array(new_coords)
+    def set_black_coords(self, new_coords):
+        self.b_coords = np.array(new_coords)
 
 
     # function to reset board to starting position  
@@ -616,6 +620,7 @@ class Grid():
         
         piece = self.grid[move[0][0]][move[0][1]]
         piece.set_moved(True)
+        # castling
         if self.get_castle_kingside():
             if color:  # black to move
                 # king on e8, hasn't moved
@@ -660,6 +665,7 @@ class Grid():
                 self.w_coords[rook.id] = [0,3]
                 rook.set_moved(True)
             self.set_castle_queenside(0)
+        # en passant
         elif self.get_someone_attempting_enpassant_move():
             if color:  # black en passanting white
                 sign = 1
@@ -683,6 +689,7 @@ class Grid():
             self.grid[move[1][0]][move[1][1]] = piece
             self.grid[move[0][0]][move[0][1]] = 0
             self.set_someone_attempting_enpassant_move(False)
+        # normal move
         else:
             piece2 = self.grid[move[1][0]][move[1][1]]
             self.grid[move[1][0]][move[1][1]] = piece
@@ -791,3 +798,24 @@ class Grid():
     # method to caulculate material difference
     def material_count(self):
         self.material_diff = np.sum(self.material_w) - np.sum(self.material_b)
+
+    
+    # method to set all pieces to not moved (for history boards)
+    def set_unmoved(self):
+        for piece in self.w_pcs:
+            piece.set_moved(False)
+        for piece in self.b_pcs:
+            piece.set_moved(False)
+
+
+    # method to set grid according to coordinates (for history boards)
+    def set_grid(self, white, black):
+        for n in range(8):
+            for m in range(8):
+                self.grid[n][m] = 0
+        type_mapping = {0:0, 1:1, 2:2, 3:2, 4:3, 5:3, 6:4, 7:4, 
+                        8:5, 9:5, 10:5, 11:5, 12:5, 13:5, 14:5, 15:5}
+        for index, coord in enumerate(white):
+            self.grid[coord[0]][coord[1]] = Piece(0, type_mapping[index], index)
+        for index, coord in enumerate(black):
+            self.grid[coord[0]][coord[1]] = Piece(1, type_mapping[index], index)

--- a/init_db.py
+++ b/init_db.py
@@ -23,7 +23,8 @@ def initialize_database():
         CREATE TABLE games (
             game_id SERIAL PRIMARY KEY,
             user_id INTEGER REFERENCES users(user_id),
-            game_history TEXT NOT NULL
+            game_history TEXT NOT NULL,
+            game_time TIMESTAMP NOT NULL
         );
                     
         CREATE INDEX idx_games_user_id ON games (user_id);

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -27,6 +27,13 @@ body {
     outline: 5px solid rgb(84, 84, 84);
 }
 
+.game-history-container {
+    display: grid;
+    grid-template-columns: repeat(8, 50px);
+    grid-template-rows: repeat(8, 50px);
+    outline: 5px solid rgb(84, 84, 84);
+}
+
 .row {
     display: flex;
     justify-content: space-between;
@@ -71,6 +78,17 @@ body {
     border: none;
 }
 
+.square-hist {
+    width: 25px;
+    height: 25px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    border: none;
+}
+
+
 #column-labels {
     display: flex;
     justify-content: space-between;
@@ -110,6 +128,11 @@ body {
 .piece {
     width: 45px;
     height: 45px;
+}
+
+.piece-hist {
+    width: 20px;
+    height: 20px;
 }
 
 .selected {
@@ -243,24 +266,43 @@ body {
 
 .top-right {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 10px;
+    right: 10px;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    gap: 10px;
 }
 
 .bottom-right {
     position: absolute;
-    bottom: 0;
-    right: 0;
+    bottom: 10px;
+    right: 10px;
     display: flex;
     flex-direction: column;
     align-items: flex-end;
-    gap: 10px;
+}
+
+.bottom-left {
+    position: absolute;
+    bottom: 10px;
+    left: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
 }
 
 table, th, td {
     border: 1px solid black;
   }
+
+p {
+    display: inline-block;
+    background-color: #11433c34;
+    color: white;
+    padding: 5px;
+    margin: 5px;
+    border: 3px solid #93a738;
+    border-radius: 8px;
+    font-family: "Lucida Console", "Courier New", monospace;
+    font-size: 10px;
+}

--- a/static/script/history.js
+++ b/static/script/history.js
@@ -1,0 +1,232 @@
+const chessBoards = {};
+const moveCounters = {};
+const coords = {};
+
+class ChessBoardHistory {
+
+    constructor(gameID) {
+        console.log("Games2js: ", games2js)
+        this.gameMoves = this.getMovesById(games2js, gameID);
+        console.log("Moves found: ", this.gameMoves, " via id: ", gameID)
+        this.gameContainer = document.getElementById(`game-container-${gameID}`);
+        this.gameContainerWrapper = document.getElementById(`game-container-wrapper-${gameID}`);
+        this.rowLabels = document.getElementById(`row-labels-${gameID}`);
+        this.columnLabels = document.getElementById(`column-labels-${gameID}`);
+        this.leftButton = document.getElementById(`left-${gameID}`);
+        this.rightButton = document.getElementById(`right-${gameID}`);
+        this.leftButton.addEventListener('click', () => this.moveLeft(gameID));
+        this.rightButton.addEventListener('click', () => this.moveRight(gameID));
+        this.names_w = {
+            0: "K", 1: "Q", 2: "R", 3: "R", 4: "N", 5: "N", 6: "B", 7: "B",
+            8: "P", 9: "P", 10: "P", 11: "P", 12: "P", 13: "P", 14: "P", 15: "P"
+        };
+        this.names_b = {
+            0: "K", 1: "Q", 2: "R", 3: "R", 4: "N", 5: "N", 6: "B", 7: "B",
+            8: "P", 9: "P", 10: "P", 11: "P", 12: "P", 13: "P", 14: "P", 15: "P"
+        };
+        this.renderBoard(
+            [[0,4], [0,3], [0,0], [0,7], [0,1],
+            [0,6], [0,2], [0,5], [1,0], [1,1], 
+            [1,2], [1,3], [1,4], [1,5], [1,6], [1,7]],
+            [[7,4], [7,3], [7,0], [7,7], [7,1], 
+            [7,6], [7,2], [7,5], [6,0], [6,1], 
+            [6,2], [6,3], [6,4], [6,5], [6,6], [6,7]],
+            gameID
+        )
+        this.renderLabels();
+    }
+
+
+    async makeMove(gameID, move) {
+        try {
+            const response = await fetch(`/move`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ move, gameID })
+            });
+            const result = await response.json();
+            if (result.status === 'move applied') {
+                this.updateBoard(result.w_coords, result.b_coords, result.promotion, gameID);
+                console.log("returning: ", [result.w_coords, result.b_coords])
+                return [result.w_coords, result.b_coords];
+            } else {
+                alert("Error in response from makeMove");
+                console.log("Backend didn't apply move: ")
+            }
+        } catch (error) {
+            console.error("Error during makeMove: ", error);
+        }
+    }
+
+
+    async fetchAndRender(gameID) {
+        const response = await fetch(`/state`);
+        const state = await response.json();
+        this.renderBoard(state.w_coords, state.b_coords, gameID);
+    }
+
+
+    async fetchCoordinates() {
+        const response = await fetch(`/state`);
+        const state = await response.json();
+        return [state.w_coords, state.b_coords];
+    }
+
+
+    updateBoard(w_coords, b_coords, promotion, gameID) {
+        if (promotion) {
+            this.promoteQueen(promotion);
+        }
+        this.renderBoard(w_coords, b_coords, gameID);
+    }
+
+
+    renderBoard(w_coords, b_coords, gameID) {
+        this.gameContainer.innerHTML = '';
+        for (let row = 0; row < 8; row++) {
+            for (let col = 0; col < 8; col++) {
+                const square = document.createElement('button');
+                square.classList.add('square', (row + col) % 2 === 0 ? 'light' : 'dark');
+                square.dataset.coordinate = `${7 - row},${col},${gameID}`;
+                this.gameContainer.appendChild(square);
+            }
+        }
+        this.renderPieces(w_coords, 0, gameID);
+        this.renderPieces(b_coords, 1, gameID);
+    }
+
+
+    renderPieces(coords, color, gameID) {
+        const names = color ? this.names_b : this.names_w;
+        coords.forEach((coord, index) => {
+            const square = document.querySelector(`[data-coordinate='${coord[0]},${coord[1]},${gameID}']`);
+            if (square) {
+                const img = document.createElement('img');
+                img.src = this.getPieceImageUrl(names[index], color);
+                img.classList.add('piece');
+                square.appendChild(img);
+            }
+        });
+    }
+
+
+    renderLabels() {
+        this.columnLabels.innerHTML = '';
+        const columns = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+        columns.forEach(letter => {
+            const label = document.createElement('div');
+            label.className = 'coordinate-label';
+            label.innerText = letter;
+            this.columnLabels.appendChild(label);
+        });
+        this.rowLabels.innerHTML = '';
+        const rows = ['8', '7', '6', '5', '4', '3', '2', '1'];
+        rows.forEach(row => {
+            const label = document.createElement('div');
+            label.className = 'coordinate-label';
+            label.innerText = row;
+            this.rowLabels.appendChild(label);
+        });
+    }
+
+
+    promoteQueen(input) {
+        let names = input.color ? this.names_b : this.names_w;
+        names[input.index] = 'Q';
+        const square = document.querySelector(`[data-coordinate='${input.coord}']`);
+        if (square) {
+            const img = square.querySelector('img');
+            img.src = this.getPieceImageUrl('Q', input.color);
+        }
+    }
+
+
+    getPieceImageUrl(type, color) {
+        switch (type) {
+            case 'Q':
+                return color ? '/static/images/Qb.png' : '/static/images/Qw.png';
+            case 'K':
+                return color ? '/static/images/Kb.png' : '/static/images/Kw.png';
+            case 'R':
+                return color ? '/static/images/Rb.png' : '/static/images/Rw.png';
+            case 'B':
+                return color ? '/static/images/Bb.png' : '/static/images/Bw.png';
+            case 'N':
+                return color ? '/static/images/Nb.png' : '/static/images/Nw.png';
+            case 'P':
+                return color ? '/static/images/Pb.png' : '/static/images/Pw.png';
+            default:
+                return '/static/images/empty.png';
+        }
+    }
+
+
+    async moveLeft(gameID) {
+        const chessBoard = chessBoards[gameID];
+        if (chessBoard) {
+            const gameCoords = coords[gameID];
+            console.log("coordinates list: ", gameCoords);
+            if (gameCoords.length > 1) {
+                gameCoords.pop();
+                console.log("coordinates list after pop: ", gameCoords);
+                const [w_coords, b_coords] = gameCoords[gameCoords.length - 1];
+                const move = ["revert", w_coords, b_coords];
+                const result = await this.makeMove(gameID, move);
+                console.log("result: " , result, ", rendering board with coordinates: (white): ", w_coords, ", (black):", b_coords)
+                chessBoard.renderBoard(w_coords, b_coords);
+                moveCounters[gameID] -= 1;
+            }
+        } else {
+            console.error(`No ChessBoard instance found for game ${gameId}`);
+        }
+    }
+
+    async moveRight(gameID) {
+        const chessBoard = chessBoards[gameID];
+        if (chessBoard) {
+            if (moveCounters[gameID] < this.gameMoves.length) {
+                console.log("Moves list: ", this.gameMoves, ", index of move: ", moveCounters[gameID]);
+                let move = this.gameMoves[moveCounters[gameID]];
+                if (move.length === 2) { move.push("nothingtoseehere") }
+                console.log("Move to be applied: ", move);
+                const [w_coords, b_coords] = await chessBoard.makeMove(gameID, move);
+                console.log("Coordinates received: (white): ", w_coords, ", (black):", b_coords);
+                console.log("pushing to coords: ", [w_coords, b_coords]);
+                coords[gameID].push([w_coords, b_coords]);
+                console.log("updated to coords: ", coords[gameID]);
+                moveCounters[gameID] += 1;
+            }
+        } else {
+            console.error(`No ChessBoard instance found for game ${gameID}`);
+        }
+    }
+
+    getMovesById(gamesList, gameID) {
+        console.log("getGameById called with games: ", gamesList, " and gameID: ", gameID);
+        const foundGame = gamesList.find(searchGame => searchGame.id === parseInt(gameID));
+        console.log("Found game: ", foundGame);
+        let movesInJSON = foundGame.moves.replace(/{{/g, '[').replace(/}}/g, ']').replace(/{/g, '[').replace(/}/g, ']').replace(/"/g, '"');
+        movesInJSON = `[${movesInJSON}]`;
+        console.log("Moves in JSON: ", movesInJSON);
+        const ret = JSON.parse(movesInJSON);
+        console.log("Parsed moves: ", ret);
+        return ret;
+    }
+}
+
+
+document.addEventListener('DOMContentLoaded', () => {
+    const boards = document.querySelectorAll('.game-history-container');
+    boards.forEach(boardElement => {
+        const gameID = boardElement.id.split('-')[2];
+        const chessBoard = new ChessBoardHistory(gameID);
+        chessBoards[gameID] = chessBoard;
+        moveCounters[gameID] = 0;
+        // need to use .then because of async as to not save the promise but the resolved value
+        chessBoard.fetchCoordinates().then(coordinates => {
+            coords[gameID] = [coordinates];
+        });
+    });
+});

--- a/templates/game_history.html
+++ b/templates/game_history.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8">
     <title>Game History</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
+    <style>
+        .game-history {
+            max-height: 500px;
+            overflow-y: auto;
+        }
+    </style>
 </head>
 <body>
     <div id="main-container">
@@ -14,15 +20,27 @@
             <table>
                 <thead>
                     <tr>
-                        <th>Game ID</th>
-                        <th>Moves</th>
+                        <th>Time played</th>
+                        <th>Game</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for game in games %}
                     <tr>
-                        <td>{{ game.id }}</td>
-                        <td>{{ game.game }}</td>
+                        <td>{{ game.time }}</td>
+                        <td>
+                            <h3>Game ID:{{ game.id }}</h3>
+                            <div id="game-container-wrapper-{{ game.id }}">
+                                <div id="row-labels-{{ game.id }}"></div>
+                                <div class='game-history-container' id="game-container-{{ game.id }}"></div>
+                            </div>
+                            <div id="column-labels-{{ game.id }}"></div>
+                            <div class="navigation-buttons">
+                                <button id="left-{{ game.id }}">&larr;</button>
+                                <button id="right-{{ game.id }}">&rarr;</button>
+                            </div>
+                        </td>
+                       
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -32,6 +50,9 @@
             <button type="submit" class="button">Back</button>
         </form>
     </div>
-    <script src="{{ url_for('static', filename='script/chessboard.js') }}"></script>
+    <script>
+        const games2js = {{ games | tojson }};
+    </script>
+    <script src="{{ url_for('static', filename='script/history.js') }}"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -70,6 +70,9 @@
                 <button type="submit" class="button" id="logout">Logout</button>
             </form>
         </div>
+        <div class="bottom-left">
+            <p>Logged in as {{ username }}</p>
+        </div>
     </div>
     <script src="{{ url_for('static', filename='script/chessboard.js') }}"></script>
 </body>


### PR DESCRIPTION
Fixes #74 
Rendering game boards with left/right arrows to move forward and backward through the moves.
Added a global dict to store Game() instances to run the history boards. Using a stack to move back one move and using existing backend code to move forward one move. 