### PR TITLE
Added dragging and dropping functionality

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -152,6 +152,18 @@ body {
     box-shadow: inset 2px 2px 5px #000000; 
 }
 
+/* Remove focus outline for dragging */
+.square:focus,
+.piece:focus,
+.square:active,
+.piece:active {
+    outline: none;
+}
+
+.dragging .piece {
+    cursor: move;
+}
+
 .invalid-move {
     background-color: red !important;
 }


### PR DESCRIPTION
Fixes #105 

Added methods for handling drag start (saving start coordinate), drag over (just a preventDefault call), drag end (just removes 'dragging' class), and drop (gets start square via dataTransfer.getData and calls makeMove with move = [start coordinate, drop coordinate] )